### PR TITLE
Improve summarization of a post

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -27,7 +27,7 @@ export class Agent {
         const content = feedItem.content;
         if (content) {
           const hydratedPostResult = await describeOnePost(content);
-          if (hydratedPostResult.result && hydratedPostResult.result !== '""') {
+          if (hydratedPostResult.result) {
             contentItems.push(hydratedPostResult.result);
           }
         }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -24,6 +24,10 @@ Post: ${post}
 Respond with only the summary or an empty string - no additional text, labels or explanations.`,
   });
   console.info({ post, result: text, usage });
+  if (text === '""') {
+    // not enough info to summarize
+    return { input: post, result: '', usage }; // normalize empty string from LLM to a JavaScript empty string
+  }
   return { input: post, result: text, usage };
 }
 

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -17,14 +17,11 @@ export interface PersonaResult {
 export async function describeOnePost(post: string): Promise<ResultText> {
   const { text, usage } = await generateText({
     model: anthropic('claude-3-5-haiku-20241022'),
-    prompt: `Write a clear, two-sentence summary of this post that captures both its key message and supporting context.
-The summary should be self-contained and preserve the original tone.
-If unable to generate a summary due to insufficient content, provide an empty summary.
+    prompt: `If this text contains enough meaningful content for summarization, write a clear, two-sentence summary that captures both its key message and supporting context. The summary should be self-contained and preserve the original tone. If the text is empty, contains only formatting/markup, or lacks sufficient meaningful content for a proper summary, respond with an empty string ("").
 
-Post:
-${post}
+Post: ${post}
 
-Respond with only the summary, no additional text or labels.`,
+Respond with only the summary or an empty string - no additional text, labels or explanations.`,
   });
   console.info({ post, result: text, usage });
   return { input: post, result: text, usage };

--- a/src/lib/bluesky.ts
+++ b/src/lib/bluesky.ts
@@ -69,7 +69,13 @@ export class Bluesky {
     return profile;
   }
 
-  async retrieveAuthorFeed(actor: string): Promise<BlueskyFeedItem[]> {
+  async retrieveAuthorFeed({
+    actor,
+    maxPosts = 50,
+  }: {
+    actor: string;
+    maxPosts?: number;
+  }): Promise<BlueskyFeedItem[]> {
     if (!this.bluesky) {
       throw new Error('Bluesky not logged in?');
     }
@@ -77,6 +83,7 @@ export class Bluesky {
     const feedItems: BlueskyFeedItem[] = [];
 
     let cursor: string | undefined = undefined;
+    let count = 0;
 
     do {
       const { data } = await this.bluesky.getAuthorFeed({
@@ -90,7 +97,8 @@ export class Bluesky {
       }
 
       cursor = data.cursor;
-    } while (cursor);
+      count += data.feed.length;
+    } while (cursor && count < maxPosts);
 
     return feedItems;
   }


### PR DESCRIPTION
- only retrieve and analyze last 50 posts for a user.
- use hydrated posts instead of raw posts to generate persona (fix)
- properly handle case where posts don't have enough info to summarize (fix)
- don't persist profile if persona not generated